### PR TITLE
fix: local key size should be 1024 bit

### DIFF
--- a/src/main/java/net/java/otr4j/OtrKeyManagerImpl.java
+++ b/src/main/java/net/java/otr4j/OtrKeyManagerImpl.java
@@ -157,7 +157,9 @@ public class OtrKeyManagerImpl implements OtrKeyManager {
 		String accountID = sessionID.getAccountID();
 		KeyPair keyPair;
 		try {
-			keyPair = KeyPairGenerator.getInstance("DSA").genKeyPair();
+			final KeyPairGenerator kg = KeyPairGenerator.getInstance("DSA");
+			kg.initialize(1024);
+			keyPair = kg.genKeyPair();
 		} catch (NoSuchAlgorithmException e) {
 			e.printStackTrace();
 			return;


### PR DESCRIPTION
On never JRE versions the default key size was increased and this broke compatibility.

When start OTR session from Pidgin the exception is thrown:
```
java.lang.IllegalArgumentException: standard length exceeded for value
	at net.java.otr4j.crypto.Util.asUnsignedByteArray(Util.java:157)
	at net.java.otr4j.crypto.OtrCryptoEngineImpl.bytesModQ(OtrCryptoEngineImpl.java:344)
	at net.java.otr4j.crypto.OtrCryptoEngineImpl.sign(OtrCryptoEngineImpl.java:262)
	at net.java.otr4j.session.AuthContextImpl$MessageFactoryImpl.getRevealSignatureMessage(AuthContextImpl.java:127)
	at net.java.otr4j.session.AuthContextImpl.handleDHKeyMessage(AuthContextImpl.java:665)
	at net.java.otr4j.session.AuthContextImpl.handleReceivingMessage(AuthContextImpl.java:457)
	at net.java.otr4j.session.SessionImpl.transformReceiving(SessionImpl.java:465)
```

To fix that we need to specify the key size as it's made in the
https://github.com/jitsi/otr4j/blob/f0f58c5f683b18f69d5702a941e9d5812858f5d1/src/main/java/net/java/otr4j/crypto/OtrCryptoEngineImpl.java#L75-L74