### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,17 +19,17 @@ jobs:
     name: Java ${{ matrix.java }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9  # v2
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
           check-latest: true
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace  # v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -45,10 +45,10 @@ jobs:
     needs: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9  # v2
         with:
           java-version: 8
           distribution: 'adopt'
@@ -57,7 +57,7 @@ jobs:
           server-password: SONATYPE_PW
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace  # v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).